### PR TITLE
Surface Matty message fetch failures instead of hiding them

### DIFF
--- a/matty.py
+++ b/matty.py
@@ -6,11 +6,13 @@ import json
 import os
 import re
 import sys
+from collections.abc import Awaitable
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from pathlib import Path
+from typing import NoReturn
 from urllib.parse import urlparse
 
 import typer
@@ -72,6 +74,25 @@ class ServerState(BaseModel):
 
 # State storage - single state per matty instance
 _state: ServerState | None = None
+
+
+class MessageFetchError(Exception):
+    """Raised when fetching room messages fails."""
+
+    @classmethod
+    def from_detail(cls, detail: str) -> "MessageFetchError":
+        """Build a fetch error with consistent user-facing text."""
+        return cls(f"Failed to get messages: {detail}")
+
+    @classmethod
+    def from_exception(cls, exc: Exception) -> "MessageFetchError":
+        """Build a fetch error from a lower-level exception."""
+        return cls.from_detail(str(exc))
+
+
+def _raise_message_fetch_error(detail: str) -> NoReturn:
+    """Raise a message fetch error with consistent formatting."""
+    raise MessageFetchError.from_detail(detail)
 
 
 # =============================================================================
@@ -609,22 +630,24 @@ async def _get_messages(client: AsyncClient, room_id: str, limit: int = 20) -> l
     Note: The Matrix API returns all timeline events, not just messages. Custom events
     (like com.mindroom.agent.activity), state events, and other non-message events are
     included in the limit, so you may get fewer actual messages than requested.
+
+    Raises:
+        MessageFetchError: If the homeserver request fails or returns invalid data.
     """
     try:
         response = await client.room_messages(room_id, limit=limit)
 
-        # Check if response is an error
-        if not hasattr(response, "chunk"):
-            console.print("[red]Error fetching messages[/red]")
-            return []
+        if isinstance(response, ErrorResponse):
+            _raise_message_fetch_error(response.message)
 
+        events = response.chunk
         messages = []
         thread_roots = set()  # Track which messages have threads
         reactions_map = {}  # event_id -> {emoji: [users]}
         edits_map = {}  # original_event_id -> latest_edit_event
 
         # First pass: collect edits
-        for event in response.chunk:
+        for event in events:
             if isinstance(event, RoomMessageText):
                 content = _get_event_content(event)
                 # Check if this is an edit (m.replace relation)
@@ -640,7 +663,7 @@ async def _get_messages(client: AsyncClient, room_id: str, limit: int = 20) -> l
                     edits_map[original_id] = event
 
         # Second pass: build message list
-        for event in response.chunk:
+        for event in events:
             if isinstance(event, RoomMessageText):
                 # Skip if this is an edit event (already processed)
                 content = _get_event_content(event)
@@ -725,9 +748,10 @@ async def _get_messages(client: AsyncClient, room_id: str, limit: int = 20) -> l
         # Assign handles to messages
         return _assign_message_handles(messages)
 
-    except Exception as e:
-        console.print(f"[red]Failed to get messages: {e}[/red]")
-        return []
+    except MessageFetchError:
+        raise
+    except Exception as exc:
+        raise MessageFetchError.from_exception(exc) from exc
 
 
 async def _get_threads(client: AsyncClient, room_id: str, limit: int = 50) -> list[Message]:
@@ -1213,6 +1237,15 @@ async def _execute_send_command(
         await client.close()
 
 
+def _run_async_command(coro: Awaitable[None]) -> None:
+    """Run an async CLI command and surface fetch failures as CLI errors."""
+    try:
+        asyncio.run(coro)
+    except MessageFetchError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
 # =============================================================================
 # DRY Helper Functions for CLI Commands
 # =============================================================================
@@ -1298,7 +1331,7 @@ def rooms(  # pragma: no cover
     format: OutputFormat = _OUTPUT_FORMAT_OPT,
 ):
     """List all joined rooms. (alias: r)"""
-    asyncio.run(_execute_rooms_command(username, password, format))
+    _run_async_command(_execute_rooms_command(username, password, format))
 
 
 @app.command("messages")
@@ -1313,7 +1346,7 @@ def messages(  # pragma: no cover
 ):
     """Show recent messages from a room. (alias: m)"""
     _validate_required_args(ctx, room=room)
-    asyncio.run(_execute_messages_command(room, limit, username, password, format))
+    _run_async_command(_execute_messages_command(room, limit, username, password, format))
 
 
 @app.command("users")
@@ -1327,7 +1360,7 @@ def users(  # pragma: no cover
 ):
     """Show users in a room. (alias: u)"""
     _validate_required_args(ctx, room=room)
-    asyncio.run(_execute_users_command(room, username, password, format))
+    _run_async_command(_execute_users_command(room, username, password, format))
 
 
 @app.command("send")
@@ -1353,7 +1386,7 @@ def send(  # pragma: no cover
         message = file.read_text()
 
     _validate_required_args(ctx, room=room, message=message)
-    asyncio.run(_execute_send_command(room, message, username, password, not no_mentions))
+    _run_async_command(_execute_send_command(room, message, username, password, not no_mentions))
 
 
 @app.command("threads")
@@ -1423,7 +1456,7 @@ def threads(  # pragma: no cover
                     )
                 )
 
-    asyncio.run(_threads())
+    _run_async_command(_threads())
 
 
 @app.command("thread")
@@ -1503,7 +1536,7 @@ def thread(  # pragma: no cover
                     )
                 )
 
-    asyncio.run(_thread())
+    _run_async_command(_thread())
 
 
 @app.command("reply")
@@ -1544,7 +1577,7 @@ def reply(  # pragma: no cover
             else:
                 console.print("[red]✗ Failed to send reply[/red]")
 
-    asyncio.run(_reply())
+    _run_async_command(_reply())
 
 
 @app.command("thread-start")
@@ -1590,7 +1623,7 @@ def thread_start(  # pragma: no cover
             else:
                 console.print("[red]✗ Failed to start thread[/red]")
 
-    asyncio.run(_thread_start())
+    _run_async_command(_thread_start())
 
 
 @app.command("thread-reply")
@@ -1630,7 +1663,7 @@ def thread_reply(  # pragma: no cover
             else:
                 console.print("[red]✗ Failed to send thread reply[/red]")
 
-    asyncio.run(_thread_reply())
+    _run_async_command(_thread_reply())
 
 
 @app.command("react")
@@ -1672,7 +1705,7 @@ def react(  # pragma: no cover
             else:
                 console.print("[red]✗ Failed to send reaction[/red]")
 
-    asyncio.run(_react())
+    _run_async_command(_react())
 
 
 @app.command("edit")
@@ -1744,7 +1777,7 @@ def edit(  # pragma: no cover
             except Exception as e:
                 console.print(f"[red]Failed to edit message: {e}[/red]")
 
-    asyncio.run(_edit())
+    _run_async_command(_edit())
 
 
 @app.command("redact")
@@ -1792,7 +1825,7 @@ def redact(  # pragma: no cover
             except Exception as e:
                 console.print(f"[red]Failed to redact message: {e}[/red]")
 
-    asyncio.run(_redact())
+    _run_async_command(_redact())
 
 
 @app.command("reactions")
@@ -1859,7 +1892,7 @@ def reactions(  # pragma: no cover
                     )
                 )
 
-    asyncio.run(_reactions())
+    _run_async_command(_reactions())
 
 
 @app.command("tui")

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,6 +1,7 @@
 """Additional tests to improve coverage to >90%."""
 
 import tempfile
+from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +15,7 @@ from typer.testing import CliRunner
 
 from matty import (
     Config,
+    MessageFetchError,
     OutputFormat,
     _execute_messages_command,
     _execute_rooms_command,
@@ -235,6 +237,27 @@ class TestCLICommands:
                 with patch("asyncio.run"):
                     result = runner.invoke(app, ["messages", "Test Room"])
                     assert result.exit_code == 0
+
+    def test_cli_threads_command_surfaces_fetch_errors(self):
+        """Test CLI threads command returns a real error on message fetch failure."""
+
+        @asynccontextmanager
+        async def mock_with_client_in_room(*_args, **_kwargs):
+            yield MagicMock(spec=AsyncClient), "!room:matrix.org", "Test Room"
+
+        async def mock_get_threads(*_args, **_kwargs):
+            detail = "Forbidden"
+            raise MessageFetchError.from_detail(detail)
+
+        with (
+            patch("matty._with_client_in_room", mock_with_client_in_room),
+            patch("matty._get_threads", mock_get_threads),
+        ):
+            result = runner.invoke(app, ["threads", "Test Room"])
+
+        assert result.exit_code == 1
+        assert "Failed to get messages: Forbidden" in result.output
+        assert "No threads found" not in result.output
 
     def test_cli_send_command(self):
         """Test CLI send command."""

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -7,6 +7,7 @@ from nio import AsyncClient, ErrorResponse, MatrixRoom
 from typer.testing import CliRunner
 
 from matty import (
+    MessageFetchError,
     _find_room,
     _get_messages,
     _login,
@@ -46,8 +47,8 @@ class TestErrorHandling:
         error = ErrorResponse("Forbidden", "M_FORBIDDEN")
         client.room_messages = AsyncMock(return_value=error)
 
-        messages = await _get_messages(client, "!room:matrix.org", 10)
-        assert messages == []
+        with pytest.raises(MessageFetchError, match="Forbidden"):
+            await _get_messages(client, "!room:matrix.org", 10)
 
     @pytest.mark.asyncio
     async def test_sync_client_error(self):


### PR DESCRIPTION
## Summary
- raise a dedicated `MessageFetchError` when room timeline fetches fail instead of returning an empty message list
- route CLI entrypoints through a shared async runner so commands like `matty threads` exit non-zero and show the real fetch error
- add regression coverage for the lower-level fetch path and the `threads` command behavior

## Testing
- `uv run pytest tests/test_error_handling.py tests/test_cli_commands.py`
- `uv run pre-commit run --all-files`
- `uv run pytest tests/test_tui_snapshots.py` *(fails on clean `origin/main` in this environment due existing snapshot mismatches; verified separately before/after this change)*