### PR TITLE
Add Matrix auth commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ Matty can store Matrix access-token credentials in your user config directory:
 matty auth sso https://matrix.example.com
 ```
 
-If the homeserver advertises multiple SSO providers, list their provider IDs:
+If the homeserver advertises multiple SSO providers, list their provider IDs and labels:
 
 ```bash
 matty auth providers https://matrix.example.com
 ```
 
-Then pass the provider ID explicitly:
+Then pass the provider ID, name, or brand explicitly. Matty resolves labels like `github`
+to the canonical provider ID before opening the browser:
 
 ```bash
 matty auth sso https://matrix.example.com --idp-id github

--- a/README.md
+++ b/README.md
@@ -51,14 +51,49 @@ uv run pre-commit install
 
 ## Configuration
 
-Matty uses environment variables for configuration. Create a `.env` file in your working directory with your Matrix credentials:
+Matty can store Matrix access-token credentials in your user config directory:
 
 ```bash
-MATRIX_HOMESERVER=https://matrix.org
-MATRIX_USERNAME=your_username
-MATRIX_PASSWORD=your_password
-MATRIX_SSL_VERIFY=true  # Set to false for test servers
+matty auth sso https://matrix.example.com
 ```
+
+If the homeserver advertises multiple SSO providers, list their provider IDs:
+
+```bash
+matty auth providers https://matrix.example.com
+```
+
+Then pass the provider ID explicitly:
+
+```bash
+matty auth sso https://matrix.example.com --idp-id github
+```
+
+Existing Matrix access token:
+
+```bash
+matty auth token https://matrix.example.com @alice:example.com "$MATRIX_ACCESS_TOKEN" --device-id DEVICEID
+```
+
+Password auth, when enabled by the homeserver:
+
+```bash
+matty auth password https://matrix.example.com @alice:example.com
+```
+
+Credentials are stored in the config file reported by:
+
+```bash
+matty config-path
+```
+
+Remove stored credentials:
+
+```bash
+matty auth logout
+```
+
+Environment variables are still supported and override stored credentials.
 
 ### Environment Variables
 
@@ -67,10 +102,13 @@ MATRIX_SSL_VERIFY=true  # Set to false for test servers
 | `MATRIX_HOMESERVER` | The Matrix homeserver URL to connect to | `https://matrix.org` | `https://matrix.example.com` |
 | `MATRIX_USERNAME` | Your Matrix username (without @ or :server) | None (required) | `alice` |
 | `MATRIX_PASSWORD` | Your Matrix account password | None (required) | `secretpassword` |
+| `MATRIX_USER_ID` | Full Matrix user ID for access-token auth | None | `@alice:example.com` |
+| `MATRIX_DEVICE_ID` | Matrix device ID for access-token auth | None | `DEVICEID` |
+| `MATRIX_ACCESS_TOKEN` | Matrix access token | None | `syt_...` |
 | `MATRIX_SSL_VERIFY` | Whether to verify SSL certificates | `true` | `false` (for test servers) |
 
 **Notes:**
-- The username should be provided without the `@` prefix or `:server` suffix
+- `MATRIX_USERNAME` should be provided without the `@` prefix or `:server` suffix
 - Set `MATRIX_SSL_VERIFY=false` when connecting to test servers with self-signed certificates
 - Command-line options (`--username`, `--password`) override environment variables
 
@@ -98,6 +136,7 @@ MATRIX_SSL_VERIFY=true  # Set to false for test servers
 │ --help                -h        Show this message and exit.                            │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────╮
+│ config-path   Print the path to the Matty credential config file.                      │
 │ rooms         List all joined rooms. (alias: r)                                        │
 │ messages      Show recent messages from a room. (alias: m)                             │
 │ users         Show users in a room. (alias: u)                                         │
@@ -112,6 +151,7 @@ MATRIX_SSL_VERIFY=true  # Set to false for test servers
 │ redact        Delete/redact a message using its handle. (alias: del)                   │
 │ reactions     Show detailed reactions for a specific message. (alias: rxs)             │
 │ tui           Launch interactive TUI chat interface.                                   │
+│ auth                                                                                   │
 ╰────────────────────────────────────────────────────────────────────────────────────────╯
 
 ```

--- a/matty/auth.py
+++ b/matty/auth.py
@@ -1,0 +1,260 @@
+"""Matrix authentication helpers for Matty."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from urllib.parse import parse_qs, quote, urlencode, urlsplit
+
+import httpx
+from nio import AsyncClient, LoginResponse
+
+
+@dataclass(frozen=True)
+class SSOProvider:
+    """Matrix SSO identity provider."""
+
+    id: str
+    name: str | None = None
+    brand: str | None = None
+
+
+@dataclass(frozen=True)
+class LoginResult:
+    """Successful Matrix login details."""
+
+    homeserver: str
+    user_id: str
+    device_id: str | None
+    access_token: str
+    ssl_verify: bool = True
+
+
+def build_sso_redirect_url(*, homeserver: str, redirect_url: str, idp_id: str | None = None) -> str:
+    """Build a Matrix SSO redirect URL for a local callback."""
+    base = homeserver.rstrip("/")
+    provider = f"/{quote(idp_id, safe='')}" if idp_id else ""
+    query = urlencode({"redirectUrl": redirect_url})
+    return f"{base}/_matrix/client/v3/login/sso/redirect{provider}?{query}"
+
+
+def parse_sso_providers(login_response: dict[str, Any]) -> list[SSOProvider]:
+    """Parse advertised Matrix SSO providers from a login response."""
+    providers: list[SSOProvider] = []
+    for flow in login_response.get("flows", []):
+        if not isinstance(flow, dict) or flow.get("type") != "m.login.sso":
+            continue
+        providers.extend(
+            SSOProvider(
+                id=provider["id"],
+                name=provider.get("name") if isinstance(provider.get("name"), str) else None,
+                brand=provider.get("brand") if isinstance(provider.get("brand"), str) else None,
+            )
+            for provider in flow.get("identity_providers", [])
+            if isinstance(provider, dict) and isinstance(provider.get("id"), str)
+        )
+    return providers
+
+
+def fetch_sso_providers(*, homeserver: str, ssl_verify: bool = True) -> list[SSOProvider]:
+    """Fetch advertised Matrix SSO providers for a homeserver."""
+    response = httpx.get(
+        f"{homeserver.rstrip('/')}/_matrix/client/v3/login",
+        timeout=10,
+        verify=ssl_verify,
+    )
+    _raise_for_redirect(response)
+    response.raise_for_status()
+    return parse_sso_providers(_response_json_object(response, context="Matrix login response"))
+
+
+def extract_login_token(query: str) -> str:
+    """Extract the Matrix SSO login token from a callback query string."""
+    values = parse_qs(query, keep_blank_values=False)
+    token = values.get("loginToken", [None])[0]
+    if not token:
+        msg = "Matrix SSO callback did not include loginToken"
+        raise ValueError(msg)
+    return token
+
+
+class SSOCallbackServer:
+    """Single-request local HTTP callback server for Matrix SSO."""
+
+    def __init__(self, *, host: str = "127.0.0.1", port: int = 0) -> None:
+        self.token: str | None = None
+        self.error: Exception | None = None
+        owner = self
+
+        class CallbackHandler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                try:
+                    owner.token = extract_login_token(urlsplit(self.path).query)
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b"Matty login complete. You can close this tab.")
+                except Exception as exc:
+                    owner.error = exc
+                    self.send_response(400)
+                    self.end_headers()
+                    self.wfile.write(b"Matty login failed. Return to the terminal.")
+
+            def log_message(self, format: str, *_args: object) -> None:
+                del format, _args
+
+        self._server = HTTPServer((host, port), CallbackHandler)
+        self.redirect_url = f"http://{host}:{self._server.server_port}/callback"
+
+    def wait_for_token(self) -> str:
+        """Wait for one callback request and return its login token."""
+        try:
+            self._server.handle_request()
+        finally:
+            self.close()
+        if self.error is not None:
+            raise self.error
+        if self.token is None:
+            msg = "Matrix SSO callback did not complete"
+            raise RuntimeError(msg)
+        return self.token
+
+    def close(self) -> None:
+        """Close the callback server socket."""
+        self._server.server_close()
+
+
+async def login_with_password(
+    *,
+    homeserver: str,
+    user: str,
+    password: str,
+    device_name: str = "matty",
+    ssl_verify: bool = True,
+) -> LoginResult:
+    """Login using Matrix password auth and return a stored-token result."""
+    client = AsyncClient(homeserver.rstrip("/"), user, ssl=ssl_verify)
+    try:
+        response = await client.login(password=password, device_name=device_name)
+    finally:
+        await client.close()
+    if isinstance(response, LoginResponse):
+        return LoginResult(
+            homeserver=homeserver.rstrip("/"),
+            user_id=response.user_id,
+            device_id=response.device_id,
+            access_token=response.access_token,
+            ssl_verify=ssl_verify,
+        )
+    msg = f"Matrix password login failed: {response}"
+    raise RuntimeError(msg)
+
+
+async def login_with_token(
+    *,
+    homeserver: str,
+    login_token: str,
+    device_name: str = "matty",
+    ssl_verify: bool = True,
+    http_client: httpx.AsyncClient | None = None,
+) -> LoginResult:
+    """Exchange a Matrix SSO loginToken for an access token."""
+    normalized_homeserver = homeserver.rstrip("/")
+    if http_client is not None:
+        return await _login_with_token_http(
+            http_client=http_client,
+            homeserver=normalized_homeserver,
+            login_token=login_token,
+            device_name=device_name,
+            ssl_verify=ssl_verify,
+        )
+
+    async with httpx.AsyncClient(timeout=10, verify=ssl_verify) as client:
+        return await _login_with_token_http(
+            http_client=client,
+            homeserver=normalized_homeserver,
+            login_token=login_token,
+            device_name=device_name,
+            ssl_verify=ssl_verify,
+        )
+
+
+async def _login_with_token_http(
+    *,
+    http_client: httpx.AsyncClient,
+    homeserver: str,
+    login_token: str,
+    device_name: str,
+    ssl_verify: bool,
+) -> LoginResult:
+    response = await http_client.post(
+        f"{homeserver}/_matrix/client/v3/login",
+        json={
+            "type": "m.login.token",
+            "token": login_token,
+            "initial_device_display_name": device_name,
+        },
+    )
+    _raise_for_redirect(response)
+    response.raise_for_status()
+    data = _response_json_object(response, context="Matrix token login response")
+
+    access_token = _required_string(data, "access_token", context="Matrix token login response")
+    device_id = data.get("device_id")
+    user_id = data.get("user_id")
+    if not isinstance(user_id, str):
+        user_id = await _fetch_user_id(
+            http_client=http_client,
+            homeserver=homeserver,
+            access_token=access_token,
+        )
+
+    return LoginResult(
+        homeserver=homeserver,
+        user_id=user_id,
+        device_id=device_id if isinstance(device_id, str) else None,
+        access_token=access_token,
+        ssl_verify=ssl_verify,
+    )
+
+
+async def _fetch_user_id(
+    *,
+    http_client: httpx.AsyncClient,
+    homeserver: str,
+    access_token: str,
+) -> str:
+    response = await http_client.get(
+        f"{homeserver}/_matrix/client/v3/account/whoami",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    _raise_for_redirect(response)
+    response.raise_for_status()
+    data = _response_json_object(response, context="Matrix whoami response")
+    return _required_string(data, "user_id", context="Matrix whoami response")
+
+
+def _raise_for_redirect(response: httpx.Response) -> None:
+    if not response.is_redirect:
+        return
+    location = response.headers.get("location")
+    msg = "Matrix API request was redirected before authentication completed."
+    if location:
+        msg = f"{msg} Redirect location: {location}"
+    raise RuntimeError(msg)
+
+
+def _response_json_object(response: httpx.Response, *, context: str) -> dict[str, Any]:
+    data = response.json()
+    if isinstance(data, dict):
+        return data
+    msg = f"{context} was not a JSON object"
+    raise RuntimeError(msg)
+
+
+def _required_string(data: dict[str, Any], key: str, *, context: str) -> str:
+    value = data.get(key)
+    if isinstance(value, str) and value:
+        return value
+    msg = f"{context} did not include required string field {key!r}"
+    raise RuntimeError(msg)

--- a/matty/auth.py
+++ b/matty/auth.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, quote, urlencode, urlsplit
 
 import httpx
 from nio import AsyncClient, LoginResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @dataclass(frozen=True)
@@ -67,6 +70,33 @@ def fetch_sso_providers(*, homeserver: str, ssl_verify: bool = True) -> list[SSO
     _raise_for_redirect(response)
     response.raise_for_status()
     return parse_sso_providers(_response_json_object(response, context="Matrix login response"))
+
+
+def resolve_sso_provider_id(idp_id: str, providers: Iterable[SSOProvider]) -> str:
+    """Resolve a Matrix SSO provider id, name, or brand to its advertised id."""
+    provider_list = list(providers)
+    for provider in provider_list:
+        if idp_id == provider.id:
+            return provider.id
+
+    normalized = idp_id.casefold()
+    matches = [
+        provider
+        for provider in provider_list
+        if normalized
+        in {alias.casefold() for alias in (provider.id, provider.name, provider.brand) if alias}
+    ]
+    if not matches:
+        available = ", ".join(_provider_alias_label(provider) for provider in provider_list)
+        msg = f"Matrix SSO provider {idp_id!r} is not advertised by this homeserver"
+        if available:
+            msg = f"{msg}. Available providers: {available}"
+        raise ValueError(msg)
+    if len(matches) > 1:
+        available = ", ".join(_provider_alias_label(provider) for provider in matches)
+        msg = f"Matrix SSO provider {idp_id!r} is ambiguous. Matching providers: {available}"
+        raise ValueError(msg)
+    return matches[0].id
 
 
 def extract_login_token(query: str) -> str:
@@ -258,3 +288,14 @@ def _required_string(data: dict[str, Any], key: str, *, context: str) -> str:
         return value
     msg = f"{context} did not include required string field {key!r}"
     raise RuntimeError(msg)
+
+
+def _provider_alias_label(provider: SSOProvider) -> str:
+    aliases = list(
+        dict.fromkeys(
+            alias for alias in (provider.name, provider.brand) if alias and alias != provider.id
+        )
+    )
+    if not aliases:
+        return provider.id
+    return f"{provider.id} ({'/'.join(aliases)})"

--- a/matty/cli.py
+++ b/matty/cli.py
@@ -6,11 +6,12 @@ import json
 import os
 import re
 import sys
+import webbrowser
 from collections.abc import Awaitable
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import NoReturn
 from urllib.parse import urlparse
@@ -29,11 +30,22 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from matty.auth import (
+    LoginResult,
+    SSOCallbackServer,
+    build_sso_redirect_url,
+    fetch_sso_providers,
+    login_with_password,
+    login_with_token,
+)
+
 app = typer.Typer(
     help="Functional Matrix CLI client",
     no_args_is_help=True,  # Show help when no command is provided
     context_settings={"help_option_names": ["-h", "--help"]},  # Add -h short option
 )
+auth_app = typer.Typer(no_args_is_help=True)
+app.add_typer(auth_app, name="auth")
 console = Console()
 
 # =============================================================================
@@ -423,6 +435,9 @@ class Config:
     username: str | None = None
     password: str | None = None
     ssl_verify: bool = True
+    user_id: str | None = None
+    device_id: str | None = None
+    access_token: str | None = None
 
 
 @dataclass
@@ -455,7 +470,7 @@ class Message:
     thread_handle: str | None = None  # Thread handle (t1, t2, etc.)
 
 
-class OutputFormat(str, Enum):
+class OutputFormat(StrEnum):
     """Output formats."""
 
     rich = "rich"
@@ -499,22 +514,97 @@ _NO_MENTIONS_OPT: bool = typer.Option(
 # =============================================================================
 
 
-def _load_config() -> Config:
-    """Load configuration from environment variables."""
+def _default_config_path() -> Path:
+    """Return the default stored Matty credential config path."""
+    return Path.home() / ".config" / "matty" / "config.json"
+
+
+def _resolve_config_path(config: Path | None) -> Path:
+    """Resolve an optional config file path."""
+    return config or _default_config_path()
+
+
+def _load_stored_config(path: Path | None = None) -> Config:
+    """Load stored credentials from disk, returning defaults if absent."""
+    resolved_path = _resolve_config_path(path)
+    if not resolved_path.exists():
+        return Config()
+    data = json.loads(resolved_path.read_text(encoding="utf-8"))
+    return Config(
+        homeserver=str(data.get("homeserver") or "https://matrix.org"),
+        username=data.get("username") if isinstance(data.get("username"), str) else None,
+        password=data.get("password") if isinstance(data.get("password"), str) else None,
+        ssl_verify=bool(data.get("ssl_verify", True)),
+        user_id=data.get("user_id") if isinstance(data.get("user_id"), str) else None,
+        device_id=data.get("device_id") if isinstance(data.get("device_id"), str) else None,
+        access_token=data.get("access_token")
+        if isinstance(data.get("access_token"), str)
+        else None,
+    )
+
+
+def _save_config(config: Config, path: Path | None = None) -> Path:
+    """Save Matty credentials to disk."""
+    resolved_path = _resolve_config_path(path)
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        key: value
+        for key, value in {
+            "homeserver": config.homeserver.rstrip("/"),
+            "username": config.username,
+            "password": config.password,
+            "ssl_verify": config.ssl_verify,
+            "user_id": config.user_id,
+            "device_id": config.device_id,
+            "access_token": config.access_token,
+        }.items()
+        if value is not None
+    }
+    resolved_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return resolved_path
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Read a boolean environment variable."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() != "false"
+
+
+def _load_config(path: Path | None = None) -> Config:
+    """Load configuration from stored credentials and environment variables."""
 
     load_dotenv()
+    stored = _load_stored_config(path)
 
     return Config(
-        homeserver=os.getenv("MATRIX_HOMESERVER", "https://matrix.org"),
-        username=os.getenv("MATRIX_USERNAME"),
-        password=os.getenv("MATRIX_PASSWORD"),
-        ssl_verify=os.getenv("MATRIX_SSL_VERIFY", "true").lower() != "false",
+        homeserver=os.getenv("MATRIX_HOMESERVER") or stored.homeserver,
+        username=os.getenv("MATRIX_USERNAME") or stored.username,
+        password=os.getenv("MATRIX_PASSWORD") or stored.password,
+        ssl_verify=_env_bool("MATRIX_SSL_VERIFY", stored.ssl_verify),
+        user_id=os.getenv("MATRIX_USER_ID") or stored.user_id,
+        device_id=os.getenv("MATRIX_DEVICE_ID") or stored.device_id,
+        access_token=os.getenv("MATRIX_ACCESS_TOKEN") or stored.access_token,
     )
 
 
 async def _create_client(config: Config) -> AsyncClient:
     """Create a Matrix client instance."""
-    return AsyncClient(config.homeserver, config.username, ssl=config.ssl_verify)
+    user = config.user_id or config.username or ""
+    return AsyncClient(config.homeserver, user, ssl=config.ssl_verify)
+
+
+def _authenticate_client(client: AsyncClient, config: Config) -> bool:
+    """Restore a Matrix access-token session when token credentials are configured."""
+    if not config.access_token or not config.user_id or not config.device_id:
+        return False
+    client.restore_login(
+        user_id=config.user_id,
+        device_id=config.device_id,
+        access_token=config.access_token,
+    )
+    return True
 
 
 async def _login(client: AsyncClient, password: str) -> bool:
@@ -528,6 +618,30 @@ async def _login(client: AsyncClient, password: str) -> bool:
     except Exception as e:
         console.print(f"[red]Login error: {e}[/red]")
         return False
+
+
+def _has_matrix_credentials(config: Config) -> bool:
+    """Return whether config contains either password or access-token credentials."""
+    return bool(
+        (config.username and config.password)
+        or (config.user_id and config.device_id and config.access_token)
+    )
+
+
+async def _login_or_restore(client: AsyncClient, config: Config) -> bool:
+    """Authenticate a Matrix client using token restore or password login."""
+    if _authenticate_client(client, config):
+        return True
+    if config.password:
+        return await _login(client, config.password)
+    return False
+
+
+def _missing_credentials_message() -> str:
+    """Return the user-facing message for absent credentials."""
+    return (
+        "Matrix credentials required. Run `matty auth` or set MATRIX_USERNAME and MATRIX_PASSWORD."
+    )
 
 
 async def _sync_client(client: AsyncClient, timeout: int = 10000) -> None:
@@ -1085,14 +1199,14 @@ async def _execute_rooms_command(
     if password:
         config.password = password
 
-    if not config.username or not config.password:
-        console.print("[red]Username and password required[/red]")
+    if not _has_matrix_credentials(config):
+        console.print(f"[red]{_missing_credentials_message()}[/red]")
         return
 
     client = await _create_client(config)
 
     try:
-        if await _login(client, config.password):
+        if await _login_or_restore(client, config):
             rooms = await _get_rooms(client)
 
             if format == OutputFormat.rich:
@@ -1120,14 +1234,14 @@ async def _execute_messages_command(
     if password:
         config.password = password
 
-    if not config.username or not config.password:
-        console.print("[red]Username and password required[/red]")
+    if not _has_matrix_credentials(config):
+        console.print(f"[red]{_missing_credentials_message()}[/red]")
         return
 
     client = await _create_client(config)
 
     try:
-        if await _login(client, config.password):
+        if await _login_or_restore(client, config):
             room_info = await _find_room(client, room)
 
             if not room_info:
@@ -1161,14 +1275,14 @@ async def _execute_users_command(
     if password:
         config.password = password
 
-    if not config.username or not config.password:
-        console.print("[red]Username and password required[/red]")
+    if not _has_matrix_credentials(config):
+        console.print(f"[red]{_missing_credentials_message()}[/red]")
         return
 
     client = await _create_client(config)
 
     try:
-        if await _login(client, config.password):
+        if await _login_or_restore(client, config):
             rooms = await _get_rooms(client)
 
             # Find the room
@@ -1207,14 +1321,14 @@ async def _execute_send_command(
     if password:
         config.password = password
 
-    if not config.username or not config.password:
-        console.print("[red]Username and password required[/red]")
+    if not _has_matrix_credentials(config):
+        console.print(f"[red]{_missing_credentials_message()}[/red]")
         return
 
     client = await _create_client(config)
 
     try:
-        if await _login(client, config.password):
+        if await _login_or_restore(client, config):
             # Sync to get room users for mentions
             await _sync_client(client)
 
@@ -1264,16 +1378,16 @@ async def _with_client(username: str | None = None, password: str | None = None)
     if password:
         config.password = password
 
-    if not config.username or not config.password:
-        console.print("[red]Username and password required[/red]")
+    if not _has_matrix_credentials(config):
+        console.print(f"[red]{_missing_credentials_message()}[/red]")
         yield None, None, None
         return
 
     client = await _create_client(config)
 
     try:
-        if await _login(client, config.password):
-            yield client, config.username, config.password
+        if await _login_or_restore(client, config):
+            yield client, config.user_id or config.username, config.password
         else:
             console.print("[red]Login failed[/red]")
             yield None, None, None
@@ -1299,7 +1413,7 @@ async def _with_client_in_room(
     Yields:
         tuple[AsyncClient, str, str]: (client, room_id, room_name)
     """
-    async with _with_client(username, password) as (client, user, pwd):
+    async with _with_client(username, password) as (client, _user, _pwd):
         if client is None:
             yield None, None, None
             return
@@ -1321,6 +1435,186 @@ async def _with_client_in_room(
 # =============================================================================
 # CLI Commands
 # =============================================================================
+
+
+@app.command("config-path")
+def config_path() -> None:
+    """Print the path to the Matty credential config file."""
+    typer.echo(str(_default_config_path()))
+
+
+@auth_app.command("token")
+def auth_token(
+    homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
+    user_id: str = typer.Argument(..., help="Matrix user ID, e.g. @alice:example.com"),
+    access_token: str = typer.Argument(..., help="Matrix access token"),
+    device_id: str | None = typer.Option(None, help="Matrix device ID"),
+    ssl_verify: bool = typer.Option(
+        True,
+        "--ssl-verify/--no-ssl-verify",
+        help="Verify TLS certificates for Matrix requests",
+    ),
+    config: Path | None = typer.Option(None, "--config", help="Config file to write"),
+) -> None:
+    """Store an existing Matrix access token."""
+    config_path = _save_config(
+        Config(
+            homeserver=homeserver.rstrip("/"),
+            ssl_verify=ssl_verify,
+            user_id=user_id,
+            device_id=device_id,
+            access_token=access_token,
+        ),
+        config,
+    )
+    typer.echo(f"Saved Matty credentials to {config_path}")
+
+
+@auth_app.command("password")
+def auth_password(
+    homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
+    user: str = typer.Argument(..., help="Matrix user ID or localpart"),
+    password: str = typer.Option(..., prompt=True, hide_input=True, confirmation_prompt=False),
+    device_name: str = typer.Option("matty", help="Matrix device display name"),
+    ssl_verify: bool = typer.Option(
+        True,
+        "--ssl-verify/--no-ssl-verify",
+        help="Verify TLS certificates for Matrix requests",
+    ),
+    config: Path | None = typer.Option(None, "--config", help="Config file to write"),
+) -> None:
+    """Login using Matrix password auth and store the resulting access token."""
+    result = asyncio.run(
+        login_with_password(
+            homeserver=homeserver,
+            user=user,
+            password=password,
+            device_name=device_name,
+            ssl_verify=ssl_verify,
+        )
+    )
+    config_path = _save_config(_config_from_login_result(result), config)
+    typer.echo(f"Saved Matty credentials for {result.user_id} to {config_path}")
+
+
+@auth_app.command("sso-url")
+def auth_sso_url(
+    homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
+    redirect_url: str = typer.Argument(..., help="Callback URL that receives loginToken"),
+    idp_id: str | None = typer.Option(None, help="Optional Matrix SSO provider ID"),
+    open_browser: bool = typer.Option(False, "--open", help="Open the SSO URL in a browser"),
+) -> None:
+    """Print a Matrix SSO redirect URL."""
+    url = build_sso_redirect_url(homeserver=homeserver, redirect_url=redirect_url, idp_id=idp_id)
+    typer.echo(url)
+    if open_browser:
+        webbrowser.open(url)
+
+
+@auth_app.command("providers")
+def auth_providers(
+    homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
+    ssl_verify: bool = typer.Option(
+        True,
+        "--ssl-verify/--no-ssl-verify",
+        help="Verify TLS certificates for Matrix requests",
+    ),
+) -> None:
+    """List Matrix SSO provider IDs for a homeserver."""
+    providers = fetch_sso_providers(homeserver=homeserver, ssl_verify=ssl_verify)
+    if not providers:
+        typer.echo("No Matrix SSO providers advertised by this homeserver.")
+        return
+    for provider in providers:
+        typer.echo(f"{provider.id}\t{provider.name or provider.brand or provider.id}")
+
+
+@auth_app.command("sso")
+def auth_sso(
+    homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
+    idp_id: str | None = typer.Option(None, help="Optional Matrix SSO provider ID"),
+    callback_host: str = typer.Option("127.0.0.1", help="Local callback bind host"),
+    callback_port: int = typer.Option(0, help="Local callback bind port; 0 chooses a free port"),
+    device_name: str = typer.Option("matty", help="Matrix device display name"),
+    ssl_verify: bool = typer.Option(
+        True,
+        "--ssl-verify/--no-ssl-verify",
+        help="Verify TLS certificates for Matrix requests",
+    ),
+    config: Path | None = typer.Option(None, "--config", help="Config file to write"),
+) -> None:
+    """Login through Matrix SSO in a browser and save the resulting access token."""
+    callback = SSOCallbackServer(host=callback_host, port=callback_port)
+    try:
+        url = build_sso_redirect_url(
+            homeserver=homeserver,
+            redirect_url=callback.redirect_url,
+            idp_id=idp_id,
+        )
+        typer.echo(f"Opening Matrix SSO URL: {url}")
+        webbrowser.open(url)
+        login_token = callback.wait_for_token()
+        result = asyncio.run(
+            login_with_token(
+                homeserver=homeserver,
+                login_token=login_token,
+                device_name=device_name,
+                ssl_verify=ssl_verify,
+            )
+        )
+    finally:
+        callback.close()
+    config_path = _save_config(_config_from_login_result(result), config)
+    typer.echo(f"Saved Matty credentials for {result.user_id} to {config_path}")
+
+
+@auth_app.command("login-token")
+def auth_login_token(
+    homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
+    login_token: str = typer.Argument(..., help="Single-use Matrix m.login.token value"),
+    device_name: str = typer.Option("matty", help="Matrix device display name"),
+    ssl_verify: bool = typer.Option(
+        True,
+        "--ssl-verify/--no-ssl-verify",
+        help="Verify TLS certificates for Matrix requests",
+    ),
+    config: Path | None = typer.Option(None, "--config", help="Config file to write"),
+) -> None:
+    """Exchange a Matrix SSO loginToken for an access token and save it."""
+    result = asyncio.run(
+        login_with_token(
+            homeserver=homeserver,
+            login_token=login_token,
+            device_name=device_name,
+            ssl_verify=ssl_verify,
+        )
+    )
+    config_path = _save_config(_config_from_login_result(result), config)
+    typer.echo(f"Saved Matty credentials for {result.user_id} to {config_path}")
+
+
+@auth_app.command("logout")
+def auth_logout(
+    config: Path | None = typer.Option(None, "--config", help="Config file to remove"),
+) -> None:
+    """Remove stored Matty credentials."""
+    config_path = _resolve_config_path(config)
+    if config_path.exists():
+        config_path.unlink()
+        typer.echo(f"Removed Matty credentials from {config_path}")
+        return
+    typer.echo(f"No Matty credentials found at {config_path}")
+
+
+def _config_from_login_result(result: LoginResult) -> Config:
+    """Convert an auth login result into stored Matty config."""
+    return Config(
+        homeserver=result.homeserver.rstrip("/"),
+        ssl_verify=result.ssl_verify,
+        user_id=result.user_id,
+        device_id=result.device_id,
+        access_token=result.access_token,
+    )
 
 
 @app.command("rooms")

--- a/matty/cli.py
+++ b/matty/cli.py
@@ -37,6 +37,7 @@ from matty.auth import (
     fetch_sso_providers,
     login_with_password,
     login_with_token,
+    resolve_sso_provider_id,
 )
 
 app = typer.Typer(
@@ -1501,11 +1502,28 @@ def auth_password(
 def auth_sso_url(
     homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
     redirect_url: str = typer.Argument(..., help="Callback URL that receives loginToken"),
-    idp_id: str | None = typer.Option(None, help="Optional Matrix SSO provider ID"),
+    idp_id: str | None = typer.Option(
+        None,
+        help="Optional Matrix SSO provider ID, name, or brand",
+    ),
+    ssl_verify: bool = typer.Option(
+        True,
+        "--ssl-verify/--no-ssl-verify",
+        help="Verify TLS certificates for Matrix requests",
+    ),
     open_browser: bool = typer.Option(False, "--open", help="Open the SSO URL in a browser"),
 ) -> None:
     """Print a Matrix SSO redirect URL."""
-    url = build_sso_redirect_url(homeserver=homeserver, redirect_url=redirect_url, idp_id=idp_id)
+    resolved_idp_id = _resolve_sso_provider_id(
+        homeserver=homeserver,
+        idp_id=idp_id,
+        ssl_verify=ssl_verify,
+    )
+    url = build_sso_redirect_url(
+        homeserver=homeserver,
+        redirect_url=redirect_url,
+        idp_id=resolved_idp_id,
+    )
     typer.echo(url)
     if open_browser:
         webbrowser.open(url)
@@ -1526,13 +1544,16 @@ def auth_providers(
         typer.echo("No Matrix SSO providers advertised by this homeserver.")
         return
     for provider in providers:
-        typer.echo(f"{provider.id}\t{provider.name or provider.brand or provider.id}")
+        typer.echo(f"{provider.id}\t{_sso_provider_label(provider)}")
 
 
 @auth_app.command("sso")
 def auth_sso(
     homeserver: str = typer.Argument(..., help="Matrix homeserver URL"),
-    idp_id: str | None = typer.Option(None, help="Optional Matrix SSO provider ID"),
+    idp_id: str | None = typer.Option(
+        None,
+        help="Optional Matrix SSO provider ID, name, or brand",
+    ),
     callback_host: str = typer.Option("127.0.0.1", help="Local callback bind host"),
     callback_port: int = typer.Option(0, help="Local callback bind port; 0 chooses a free port"),
     device_name: str = typer.Option("matty", help="Matrix device display name"),
@@ -1546,10 +1567,15 @@ def auth_sso(
     """Login through Matrix SSO in a browser and save the resulting access token."""
     callback = SSOCallbackServer(host=callback_host, port=callback_port)
     try:
+        resolved_idp_id = _resolve_sso_provider_id(
+            homeserver=homeserver,
+            idp_id=idp_id,
+            ssl_verify=ssl_verify,
+        )
         url = build_sso_redirect_url(
             homeserver=homeserver,
             redirect_url=callback.redirect_url,
-            idp_id=idp_id,
+            idp_id=resolved_idp_id,
         )
         typer.echo(f"Opening Matrix SSO URL: {url}")
         webbrowser.open(url)
@@ -1615,6 +1641,29 @@ def _config_from_login_result(result: LoginResult) -> Config:
         device_id=result.device_id,
         access_token=result.access_token,
     )
+
+
+def _resolve_sso_provider_id(
+    *,
+    homeserver: str,
+    idp_id: str | None,
+    ssl_verify: bool,
+) -> str | None:
+    """Resolve a user-facing SSO provider selector before starting browser auth."""
+    if idp_id is None:
+        return None
+
+    providers = fetch_sso_providers(homeserver=homeserver, ssl_verify=ssl_verify)
+    if not providers:
+        return idp_id
+    try:
+        return resolve_sso_provider_id(idp_id, providers)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc), param_hint="--idp-id") from exc
+
+
+def _sso_provider_label(provider) -> str:
+    return provider.name or provider.brand or provider.id
 
 
 @app.command("rooms")

--- a/matty/tui.py
+++ b/matty/tui.py
@@ -31,6 +31,7 @@ from matty.cli import (
     Config,
     Message,
     Room,
+    _authenticate_client,
     _create_client,
     _find_room,
     _get_event_id_from_handle,
@@ -40,6 +41,7 @@ from matty.cli import (
     _get_rooms,
     _get_thread_messages,
     _get_threads,
+    _has_matrix_credentials,
     _load_config,
     _login,
     _send_message,
@@ -58,6 +60,15 @@ POLL_INTERVAL_S = 3
 SYNC_TIMEOUT_MS = 5000
 _MAX_POLL_FAILURES = 5
 _MESSAGE_LIMIT = 50
+
+
+async def _login_or_restore(client: AsyncClient, config: Config) -> bool:
+    """Authenticate for the TUI using token restore or password login."""
+    if _authenticate_client(client, config):
+        return True
+    if config.password:
+        return await _login(client, config.password)
+    return False
 
 
 def _format_sender(sender: str) -> str:
@@ -281,9 +292,9 @@ class MattyApp(App):
     @work(exclusive=True, group="connect")
     async def _connect_and_load(self) -> None:
         """Connect to Matrix and load rooms."""
-        if not self.config.username or not self.config.password:
+        if not _has_matrix_credentials(self.config):
             self._log_to_pane(
-                "Error: Username and password required. Set MATRIX_USERNAME and MATRIX_PASSWORD."
+                "Error: Matrix credentials required. Run `matty auth` or set MATRIX_USERNAME and MATRIX_PASSWORD."
             )
             return
 
@@ -300,7 +311,7 @@ class MattyApp(App):
             client = await _create_client(self.config)
             should_close_client = True
 
-            if not await _login(client, self.config.password):
+            if not await _login_or_restore(client, self.config):
                 self._log_to_pane("Login failed. Check credentials.")
                 return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
 ]
 dependencies = [
     "aiofiles>=24.1.0",
-    "matrix-nio>=0.25.2",
+    "httpx>=0.28",
+    "mindroom-nio>=0.25",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",
     "python-dotenv>=1.1.1",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,20 +3,29 @@
 from __future__ import annotations
 
 import json
+import threading
+import urllib.error
+import urllib.request
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
+from nio import LoginResponse
 from typer.testing import CliRunner
 
 from matty import Config
 from matty.auth import (
     LoginResult,
+    SSOCallbackServer,
     SSOProvider,
     build_sso_redirect_url,
+    extract_login_token,
+    fetch_sso_providers,
+    login_with_password,
     login_with_token,
     parse_sso_providers,
+    resolve_sso_provider_id,
 )
 from matty.cli import _authenticate_client, _load_config, app
 
@@ -89,6 +98,285 @@ def test_auth_logout_removes_stored_config(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert not config_path.exists()
     assert "Removed Matty credentials" in result.output
+
+
+def test_auth_logout_is_idempotent(tmp_path: Path) -> None:
+    config_path = tmp_path / "missing.json"
+
+    result = runner.invoke(app, ["auth", "logout", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    assert "No Matty credentials found" in result.output
+
+
+def test_config_path_prints_default_path() -> None:
+    result = runner.invoke(app, ["config-path"])
+
+    assert result.exit_code == 0
+    assert result.output.strip().endswith(".config/matty/config.json")
+
+
+def test_auth_sso_url_opens_browser(monkeypatch: pytest.MonkeyPatch) -> None:
+    opened: list[str] = []
+    monkeypatch.setattr("matty.cli.webbrowser.open", opened.append)
+    monkeypatch.setattr(
+        "matty.cli.fetch_sso_providers",
+        lambda **_kwargs: [SSOProvider(id="Ov23li6wDSuBsiVjYWar", name="GitHub", brand="github")],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "sso-url",
+            "https://matrix.example.com",
+            "http://127.0.0.1:8767/callback",
+            "--idp-id",
+            "github",
+            "--open",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert (
+        "https://matrix.example.com/_matrix/client/v3/login/sso/redirect/"
+        "Ov23li6wDSuBsiVjYWar?" in result.output
+    )
+    assert opened == [result.output.strip()]
+
+
+def test_auth_providers_lists_provider_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_fetch_sso_providers(*, homeserver: str, ssl_verify: bool = True) -> list[SSOProvider]:
+        assert homeserver == "https://matrix.example.com"
+        assert ssl_verify is False
+        return [
+            SSOProvider(id="google", name="Google", brand="google"),
+            SSOProvider(id="github", name="GitHub", brand="github"),
+        ]
+
+    monkeypatch.setattr("matty.cli.fetch_sso_providers", fake_fetch_sso_providers)
+
+    result = runner.invoke(
+        app,
+        ["auth", "providers", "https://matrix.example.com", "--no-ssl-verify"],
+    )
+
+    assert result.exit_code == 0
+    assert "google\tGoogle" in result.output
+    assert "github\tGitHub" in result.output
+
+
+def test_auth_providers_reports_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("matty.cli.fetch_sso_providers", lambda **_kwargs: [])
+
+    result = runner.invoke(app, ["auth", "providers", "https://matrix.example.com"])
+
+    assert result.exit_code == 0
+    assert "No Matrix SSO providers" in result.output
+
+
+def test_auth_password_saves_login_result(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+
+    async def fake_login_with_password(**kwargs) -> LoginResult:
+        assert kwargs["homeserver"] == "https://matrix.example.com"
+        assert kwargs["user"] == "@alice:example.com"
+        assert kwargs["password"] == "secret"
+        assert kwargs["device_name"] == "matty"
+        assert kwargs["ssl_verify"] is False
+        return LoginResult(
+            homeserver="https://matrix.example.com",
+            user_id="@alice:example.com",
+            device_id="TESTDEVICE",
+            access_token="test-token",
+            ssl_verify=False,
+        )
+
+    monkeypatch.setattr("matty.cli.login_with_password", fake_login_with_password)
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "password",
+            "https://matrix.example.com",
+            "@alice:example.com",
+            "--password",
+            "secret",
+            "--no-ssl-verify",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["user_id"] == "@alice:example.com"
+    assert saved["device_id"] == "TESTDEVICE"
+    assert saved["access_token"] == "test-token"
+    assert saved["ssl_verify"] is False
+
+
+def test_auth_login_token_saves_login_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+
+    async def fake_login_with_token(**kwargs) -> LoginResult:
+        assert kwargs["login_token"] == "single-use-token"
+        return LoginResult(
+            homeserver="https://matrix.example.com",
+            user_id="@alice:example.com",
+            device_id="TESTDEVICE",
+            access_token="test-token",
+        )
+
+    monkeypatch.setattr("matty.cli.login_with_token", fake_login_with_token)
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "login-token",
+            "https://matrix.example.com",
+            "single-use-token",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["access_token"] == "test-token"
+
+
+def test_auth_sso_waits_for_callback_and_saves_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    closed: list[bool] = []
+    opened: list[str] = []
+
+    class FakeCallback:
+        redirect_url = "http://127.0.0.1:8767/callback"
+
+        def __init__(self, *, host: str, port: int) -> None:
+            assert host == "127.0.0.1"
+            assert port == 0
+
+        def wait_for_token(self) -> str:
+            self.close()
+            return "sso-login-token"
+
+        def close(self) -> None:
+            closed.append(True)
+
+    async def fake_login_with_token(**kwargs) -> LoginResult:
+        assert kwargs["login_token"] == "sso-login-token"
+        return LoginResult(
+            homeserver="https://matrix.example.com",
+            user_id="@alice:example.com",
+            device_id="TESTDEVICE",
+            access_token="test-token",
+        )
+
+    monkeypatch.setattr("matty.cli.SSOCallbackServer", FakeCallback)
+    monkeypatch.setattr("matty.cli.login_with_token", fake_login_with_token)
+    monkeypatch.setattr("matty.cli.webbrowser.open", opened.append)
+
+    result = runner.invoke(
+        app,
+        ["auth", "sso", "https://matrix.example.com", "--config", str(config_path)],
+    )
+
+    assert result.exit_code == 0
+    assert opened
+    assert closed == [True, True]
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["access_token"] == "test-token"
+
+
+def test_auth_sso_resolves_provider_name_to_advertised_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    opened: list[str] = []
+
+    class FakeCallback:
+        redirect_url = "http://127.0.0.1:8767/callback"
+
+        def __init__(self, *, host: str, port: int) -> None:
+            assert host == "127.0.0.1"
+            assert port == 0
+
+        def wait_for_token(self) -> str:
+            return "sso-login-token"
+
+        def close(self) -> None:
+            pass
+
+    async def fake_login_with_token(**_kwargs) -> LoginResult:
+        return LoginResult(
+            homeserver="https://mindroom.chat",
+            user_id="@alice:mindroom.chat",
+            device_id="TESTDEVICE",
+            access_token="test-token",
+        )
+
+    def fake_fetch_sso_providers(**_kwargs) -> list[SSOProvider]:
+        return [
+            SSOProvider(id="Ov23li6wDSuBsiVjYWar", name="github", brand="github"),
+        ]
+
+    monkeypatch.setattr("matty.cli.SSOCallbackServer", FakeCallback)
+    monkeypatch.setattr("matty.cli.login_with_token", fake_login_with_token)
+    monkeypatch.setattr("matty.cli.fetch_sso_providers", fake_fetch_sso_providers)
+    monkeypatch.setattr("matty.cli.webbrowser.open", opened.append)
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "sso",
+            "https://mindroom.chat",
+            "--idp-id",
+            "github",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert opened == [
+        (
+            "https://mindroom.chat/_matrix/client/v3/login/sso/redirect/"
+            "Ov23li6wDSuBsiVjYWar?redirectUrl=http%3A%2F%2F127.0.0.1%3A8767%2Fcallback"
+        )
+    ]
+
+
+def test_auth_sso_rejects_unknown_advertised_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "matty.cli.fetch_sso_providers",
+        lambda **_kwargs: [SSOProvider(id="Ov23li6wDSuBsiVjYWar", name="github", brand="github")],
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "sso",
+            "https://mindroom.chat",
+            "--idp-id",
+            "gitlab",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "gitlab" in result.output
+    assert "Available providers" in result.output
 
 
 def test_load_config_reads_stored_access_token(
@@ -176,6 +464,15 @@ def test_build_sso_redirect_url_includes_redirect_url() -> None:
     )
 
 
+def test_extract_login_token_from_callback_query() -> None:
+    assert extract_login_token("loginToken=abc123&state=ignored") == "abc123"
+
+
+def test_extract_login_token_requires_token() -> None:
+    with pytest.raises(ValueError, match="loginToken"):
+        extract_login_token("state=ignored")
+
+
 def test_parse_sso_providers_reads_matrix_login_flows() -> None:
     providers = parse_sso_providers(
         {
@@ -196,6 +493,139 @@ def test_parse_sso_providers_reads_matrix_login_flows() -> None:
         SSOProvider(id="google", name="Google", brand="google"),
         SSOProvider(id="github", name="GitHub", brand="github"),
     ]
+
+
+def test_resolve_sso_provider_id_accepts_name_or_brand_alias() -> None:
+    providers = [
+        SSOProvider(
+            id="974295579207-8d3ippmssoiaibuu04id02sb66rgi1h3.apps.googleusercontent.com",
+            name="google",
+            brand="google",
+        ),
+        SSOProvider(id="Ov23li6wDSuBsiVjYWar", name="github", brand="github"),
+    ]
+
+    assert resolve_sso_provider_id("github", providers) == "Ov23li6wDSuBsiVjYWar"
+    assert resolve_sso_provider_id("GOOGLE", providers) == (
+        "974295579207-8d3ippmssoiaibuu04id02sb66rgi1h3.apps.googleusercontent.com"
+    )
+
+
+def test_resolve_sso_provider_id_reports_ambiguous_alias() -> None:
+    providers = [
+        SSOProvider(id="one", name="GitHub"),
+        SSOProvider(id="two", brand="github"),
+    ]
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        resolve_sso_provider_id("github", providers)
+
+
+def test_fetch_sso_providers_reads_login_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, *, timeout: int, verify: bool) -> httpx.Response:
+        assert url == "https://matrix.example.com/_matrix/client/v3/login"
+        assert timeout == 10
+        assert verify is False
+        return httpx.Response(
+            200,
+            request=httpx.Request("GET", url),
+            json={
+                "flows": [
+                    {
+                        "type": "m.login.sso",
+                        "identity_providers": [{"id": "github", "name": "GitHub"}],
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    assert fetch_sso_providers(homeserver="https://matrix.example.com/", ssl_verify=False) == [
+        SSOProvider(id="github", name="GitHub")
+    ]
+
+
+def test_sso_callback_server_receives_login_token() -> None:
+    callback = SSOCallbackServer()
+
+    def open_callback() -> None:
+        with urllib.request.urlopen(f"{callback.redirect_url}?loginToken=abc123", timeout=10):
+            pass
+
+    thread = threading.Thread(target=open_callback)
+    thread.start()
+    try:
+        assert callback.wait_for_token() == "abc123"
+    finally:
+        thread.join(timeout=10)
+
+
+def test_sso_callback_server_reports_missing_login_token() -> None:
+    callback = SSOCallbackServer()
+
+    def open_callback() -> None:
+        with pytest.raises(urllib.error.HTTPError):
+            urllib.request.urlopen(f"{callback.redirect_url}?state=missing", timeout=10)
+
+    thread = threading.Thread(target=open_callback)
+    thread.start()
+    try:
+        with pytest.raises(ValueError, match="loginToken"):
+            callback.wait_for_token()
+    finally:
+        thread.join(timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_login_with_password_returns_login_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = AsyncMock()
+    client.login.return_value = LoginResponse("@alice:example.com", "TESTDEVICE", "test-token")
+
+    class FakeAsyncClient:
+        def __new__(cls, *args, **kwargs):
+            assert args == ("https://matrix.example.com", "@alice:example.com")
+            assert kwargs == {"ssl": False}
+            return client
+
+    monkeypatch.setattr("matty.auth.AsyncClient", FakeAsyncClient)
+
+    result = await login_with_password(
+        homeserver="https://matrix.example.com/",
+        user="@alice:example.com",
+        password="secret",
+        ssl_verify=False,
+    )
+
+    assert result == LoginResult(
+        homeserver="https://matrix.example.com",
+        user_id="@alice:example.com",
+        device_id="TESTDEVICE",
+        access_token="test-token",
+        ssl_verify=False,
+    )
+    client.login.assert_awaited_once_with(password="secret", device_name="matty")
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_login_with_password_reports_login_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = AsyncMock()
+    client.login.return_value = object()
+
+    class FakeAsyncClient:
+        def __new__(cls, *_args, **_kwargs):
+            return client
+
+    monkeypatch.setattr("matty.auth.AsyncClient", FakeAsyncClient)
+
+    with pytest.raises(RuntimeError, match="password login failed"):
+        await login_with_password(
+            homeserver="https://matrix.example.com",
+            user="@alice:example.com",
+            password="secret",
+        )
+    client.close.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -234,3 +664,70 @@ async def test_login_with_token_fetches_user_id_when_login_response_omits_it() -
         ("POST", "/_matrix/client/v3/login"),
         ("GET", "/_matrix/client/v3/account/whoami"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_login_with_token_uses_user_id_from_login_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/_matrix/client/v3/login"
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "test-access-token",
+                "device_id": "TESTDEVICE",
+                "user_id": "@alice:example.com",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        result = await login_with_token(
+            homeserver="https://matrix.example.com",
+            login_token="test-login-token",
+            http_client=http_client,
+        )
+
+    assert result.user_id == "@alice:example.com"
+    assert result.device_id == "TESTDEVICE"
+
+
+@pytest.mark.asyncio
+async def test_login_with_token_reports_redirected_matrix_api() -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                302, headers={"location": "https://gateway.example.com"}
+            )
+        )
+    ) as http_client:
+        with pytest.raises(RuntimeError, match="Redirect location"):
+            await login_with_token(
+                homeserver="https://matrix.example.com",
+                login_token="test-login-token",
+                http_client=http_client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_login_with_token_requires_access_token() -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={}))
+    ) as http_client:
+        with pytest.raises(RuntimeError, match="access_token"):
+            await login_with_token(
+                homeserver="https://matrix.example.com",
+                login_token="test-login-token",
+                http_client=http_client,
+            )
+
+
+@pytest.mark.asyncio
+async def test_login_with_token_requires_json_object() -> None:
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json=[]))
+    ) as http_client:
+        with pytest.raises(RuntimeError, match="JSON object"):
+            await login_with_token(
+                homeserver="https://matrix.example.com",
+                login_token="test-login-token",
+                http_client=http_client,
+            )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,236 @@
+"""Authentication command and helper tests."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from matty import Config
+from matty.auth import (
+    LoginResult,
+    SSOProvider,
+    build_sso_redirect_url,
+    login_with_token,
+    parse_sso_providers,
+)
+from matty.cli import _authenticate_client, _load_config, app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+runner = CliRunner()
+
+
+def _clear_matrix_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "MATRIX_HOMESERVER",
+        "MATRIX_USERNAME",
+        "MATRIX_PASSWORD",
+        "MATRIX_SSL_VERIFY",
+        "MATRIX_USER_ID",
+        "MATRIX_DEVICE_ID",
+        "MATRIX_ACCESS_TOKEN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_auth_help_lists_all_auth_modes() -> None:
+    result = runner.invoke(app, ["auth", "--help"])
+
+    assert result.exit_code == 0
+    assert "token" in result.output
+    assert "password" in result.output
+    assert "sso-url" in result.output
+    assert "providers" in result.output
+    assert "sso" in result.output
+    assert "login-token" in result.output
+    assert "logout" in result.output
+
+
+def test_auth_token_writes_stored_access_token_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "token",
+            "https://matrix.example.com/",
+            "@alice:example.com",
+            "test-token",
+            "--device-id",
+            "TESTDEVICE",
+            "--config",
+            str(config_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    assert saved["homeserver"] == "https://matrix.example.com"
+    assert saved["user_id"] == "@alice:example.com"
+    assert saved["device_id"] == "TESTDEVICE"
+    assert saved["access_token"] == "test-token"
+    assert "password" not in saved
+
+
+def test_auth_logout_removes_stored_config(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"homeserver": "https://matrix.example.com"}\n', encoding="utf-8")
+
+    result = runner.invoke(app, ["auth", "logout", "--config", str(config_path)])
+
+    assert result.exit_code == 0
+    assert not config_path.exists()
+    assert "Removed Matty credentials" in result.output
+
+
+def test_load_config_reads_stored_access_token(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_matrix_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "homeserver": "https://matrix.example.com",
+                "user_id": "@alice:example.com",
+                "device_id": "TESTDEVICE",
+                "access_token": "test-token",
+                "ssl_verify": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = _load_config(config_path)
+
+    assert config.homeserver == "https://matrix.example.com"
+    assert config.user_id == "@alice:example.com"
+    assert config.device_id == "TESTDEVICE"
+    assert config.access_token == "test-token"
+    assert config.ssl_verify is False
+
+
+def test_environment_overrides_stored_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "homeserver": "https://stored.example.com",
+                "user_id": "@stored:example.com",
+                "device_id": "STORED",
+                "access_token": "stored-token",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MATRIX_HOMESERVER", "https://env.example.com")
+    monkeypatch.setenv("MATRIX_USER_ID", "@env:example.com")
+    monkeypatch.setenv("MATRIX_DEVICE_ID", "ENVDEVICE")
+    monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "env-token")
+
+    config = _load_config(config_path)
+
+    assert config.homeserver == "https://env.example.com"
+    assert config.user_id == "@env:example.com"
+    assert config.device_id == "ENVDEVICE"
+    assert config.access_token == "env-token"
+
+
+def test_authenticate_client_restores_access_token() -> None:
+    client = MagicMock()
+    config = Config(
+        homeserver="https://matrix.example.com",
+        user_id="@alice:example.com",
+        device_id="TESTDEVICE",
+        access_token="test-token",
+    )
+
+    assert _authenticate_client(client, config) is True
+
+    client.restore_login.assert_called_once_with(
+        user_id="@alice:example.com",
+        device_id="TESTDEVICE",
+        access_token="test-token",
+    )
+
+
+def test_build_sso_redirect_url_includes_redirect_url() -> None:
+    url = build_sso_redirect_url(
+        homeserver="https://matrix.example.com",
+        redirect_url="http://127.0.0.1:8767/callback",
+    )
+
+    assert url == (
+        "https://matrix.example.com/_matrix/client/v3/login/sso/redirect?"
+        "redirectUrl=http%3A%2F%2F127.0.0.1%3A8767%2Fcallback"
+    )
+
+
+def test_parse_sso_providers_reads_matrix_login_flows() -> None:
+    providers = parse_sso_providers(
+        {
+            "flows": [
+                {"type": "m.login.password"},
+                {
+                    "type": "m.login.sso",
+                    "identity_providers": [
+                        {"id": "google", "name": "Google", "brand": "google"},
+                        {"id": "github", "name": "GitHub", "brand": "github"},
+                    ],
+                },
+            ],
+        }
+    )
+
+    assert providers == [
+        SSOProvider(id="google", name="Google", brand="google"),
+        SSOProvider(id="github", name="GitHub", brand="github"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_login_with_token_fetches_user_id_when_login_response_omits_it() -> None:
+    requests: list[tuple[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.method, request.url.path))
+        if request.url.path == "/_matrix/client/v3/login":
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "test-access-token",
+                    "device_id": "TESTDEVICE",
+                },
+            )
+        if request.url.path == "/_matrix/client/v3/account/whoami":
+            assert request.headers["authorization"] == "Bearer test-access-token"
+            return httpx.Response(200, json={"user_id": "@alice:example.com"})
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        result = await login_with_token(
+            homeserver="https://matrix.example.com",
+            login_token="test-login-token",
+            http_client=http_client,
+        )
+
+    assert result == LoginResult(
+        homeserver="https://matrix.example.com",
+        user_id="@alice:example.com",
+        device_id="TESTDEVICE",
+        access_token="test-access-token",
+    )
+    assert requests == [
+        ("POST", "/_matrix/client/v3/login"),
+        ("GET", "/_matrix/client/v3/account/whoami"),
+    ]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -259,14 +259,14 @@ class TestEdgeCases:
     def test_parse_mentions_with_full_matrix_id(self):
         """Test parsing mentions with full Matrix IDs."""
         users = ["@alice:matrix.org", "@bob:matrix.org"]
-        body, formatted, mentioned = _parse_mentions("Hello @alice:matrix.org", users)
+        _body, formatted, mentioned = _parse_mentions("Hello @alice:matrix.org", users)
         assert mentioned == ["@alice:matrix.org"]
         assert "@alice:matrix.org" in formatted
 
     def test_parse_mentions_mixed(self):
         """Test parsing mixed mention formats."""
         users = ["@alice:matrix.org", "@bob:matrix.org"]
-        body, formatted, mentioned = _parse_mentions(
+        _body, _formatted, mentioned = _parse_mentions(
             "@alice and @bob:matrix.org please review", users
         )
         assert "@alice:matrix.org" in mentioned


### PR DESCRIPTION
## Summary
- Add a `matty auth` command group with token, password, SSO URL, provider listing, browser SSO, login-token exchange, and logout flows.
- Store access-token credentials in `~/.config/matty/config.json`, add `matty config-path`, and allow environment variables to override stored credentials.
- Let CLI and TUI sessions authenticate by restoring stored access tokens as well as the existing username/password flow.
- Switch the Matrix client dependency from `matrix-nio` to `mindroom-nio` and add `httpx` for Matrix login-token HTTP calls.

## Test Plan
- [x] `uv run pytest --ignore=tests/test_tui_snapshots.py`
- [x] `uv run ruff check . --no-fix`
- [x] `uv build`
- [x] `uv run matty auth --help`
- [x] `uv run matty config-path`
- [x] `uv run python -m matty --help`
- [x] Import smoke check for `nio`, `matty.auth.LoginResult`, and SSO URL generation

## Notes
- `uv run mypy matty` still fails on the repo's broader strict-typing baseline and the untyped `nio` package import.
- Local snapshot tests remain environment-dependent and are still excluded from the primary test command.
